### PR TITLE
Get the object, then get the string within

### DIFF
--- a/src/class-create-posts.php
+++ b/src/class-create-posts.php
@@ -23,8 +23,8 @@ class Create_Posts {
 	 * @return string $title
 	 */
 	public function generate_title(): string {
-		$title = (string) new Make_Content( 1, 1 );
-		$title = wp_strip_all_tags( $title ); // Remove block paragraph formatting tags.
+		$sentences_obj = new Make_Content( 1, 1 );
+		$title = wp_strip_all_tags( $sentences_obj->sentence ); // Remove block paragraph formatting tags.
 		if ( strlen( $title ) > 150 ) {
 			// If we can cut off a long sentence on a space, let's do it.
 			$space_checker = strpos( $title, ' ', 150 );

--- a/src/class-make-content.php
+++ b/src/class-make-content.php
@@ -63,7 +63,8 @@ class Make_Content extends Canadianize {
 		for ( $y = 0; $y < $number_of_paragraphs; $y ++ ) {
 			$paragraph .= '<!-- wp:paragraph {"placeholder":"Post Paragraph"} --><p>';
 			for ( $x = 0; $x < $sentences_per_paragraph; $x ++ ) {
-				$paragraph .= wp_strip_all_tags( new Sentences ) . " ";
+				$paragraph_obj = new Sentences;
+				$paragraph .= wp_strip_all_tags( $paragraph_obj->sentence ) . " ";
 			}
 			$paragraph .= "</p><!-- /wp:paragraph -->";
 		}


### PR DESCRIPTION
Fixes the is_scalar failure inside wp_strip_all_tags when using PHP >=8

This solves https://github.com/lschuyler/canadianize/issues/11